### PR TITLE
Fixed broken link

### DIFF
--- a/index.md
+++ b/index.md
@@ -39,7 +39,7 @@ The [annual membership fee](/offer) - will give you a pile of [benefits and supp
 ##References:
 
 * Web: [www.josra.org](http://www.josra.org)
-* Roadmaps in Trello: [Http://www.trello.com/josra](www.trello.com/josra)
+* Roadmaps in Trello: [http://www.trello.com/josra](http://www.trello.com/josra)
 * Group on LinkedIn:  ["Joint Open Source Roadmap Alliance"](https://www.linkedin.com/groups/Joint-Open-Source-Roadmap-Alliance-7403229)
  
 If you are interested in joining JOSRA or if you have any questions, please contact **Lars Kruse** ([lak@praqma.com](mailto:lak@praqma.com) / +45 2087 2530)


### PR DESCRIPTION
Link to trello.com/josra was rendered as relative link because of missing http:// specifier.
